### PR TITLE
chore: add CodeQL to pr-checks merge gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,6 +51,17 @@ jobs:
     permissions:
       contents: read
 
+  # ── CodeQL Analysis ────────────────────────────────────────────────
+  codeql:
+    if: false  # Set based on CodeQL-supported languages
+    uses: valigator-tech/.github/.github/workflows/reusable-codeql.yml@main
+    with:
+      languages: '[]'
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
   # ── Merge Gate ────────────────────────────────────────────────────
   # This job produces a consistent "pr-checks" status check name
   # that org rulesets can require across all repos.


### PR DESCRIPTION
## Summary
- Add CodeQL as a toggled job in pr-checks.yml
- CodeQL disabled (no supported languages)
- CodeQL results now gated by the `pr-checks` merge gate

**Files:** pr-checks.yml

---
*Created by enforce_tier.py rollout*