### PR TITLE
Add permissions block to pr-checks merge gate job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,6 +69,7 @@ jobs:
     if: always()
     needs: [bash-checks, secrets-check]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check results
         run: |


### PR DESCRIPTION
## Summary
- Adds `permissions: {}` to the `pr-checks` merge gate job
- This job only aggregates other job results and needs no `GITHUB_TOKEN` permissions
- Resolves code scanning alert for missing workflow permissions

## Test plan
- [x] Validated on valigator-website (PR #35 merged, all checks passed)
- [ ] Verify checks pass on this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)