### PR TITLE
fix: remove dead codeql job referencing deleted reusable-codeql.yml

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,17 +51,6 @@ jobs:
     permissions:
       contents: read
 
-  # ── CodeQL Analysis ────────────────────────────────────────────────
-  codeql:
-    if: false  # Set based on CodeQL-supported languages
-    uses: valigator-tech/.github/.github/workflows/reusable-codeql.yml@main
-    with:
-      languages: '[]'
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-
   # ── Merge Gate ────────────────────────────────────────────────────
   # This job produces a consistent "pr-checks" status check name
   # that org rulesets can require across all repos.


### PR DESCRIPTION
## Summary
Remove the `codeql:` job block from `pr-checks.yml`. This job references `reusable-codeql.yml` which was deleted from the `.github` org repo on 2026-03-18.

**Impact:** GitHub validates `uses:` references at YAML parse time, even for jobs with `if: false`. The missing reference causes the entire workflow to fail with zero jobs — no linting, no secrets scanning, no merge gate.

**Fix:** Remove the entire job block. CodeQL runs via standalone `codeql.yml` where applicable.

Tracked by: GATOR-174 (parent: GATOR-173)

🤖 Generated with [Claude Code](https://claude.com/claude-code)