### PR TITLE
feat: accept chrony and ntpd as valid NTP services

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,7 +52,7 @@ sudo ./health_check.sh -h                 # Help
 | Fail2ban | `fail2ban` | Verifies fail2ban is installed, enabled, and running |
 | Swap Status | `swapStatus` | Confirms swap is disabled (configurable) |
 | Package Updates | `packageUpdates` | Checks pending updates against threshold (default: 5) |
-| NTP Sync | `ntpSync` | Verifies systemd-timesyncd is active |
+| NTP Sync | `ntpSync` | Verifies an accepted NTP service is active (systemd-timesyncd, chrony, or ntpd) and clock is synchronized |
 | Timezone | `timezoneUtc` | Confirms system timezone is UTC |
 | SSH Config | `sshConfig` | Validates SSH security (root login disabled, key-only auth) |
 | Required Packages | `requiredPackages` | Checks for rsyslog and ufw packages |

--- a/health_check.sh
+++ b/health_check.sh
@@ -762,7 +762,7 @@ else
 fi
 
 # Function to check NTP synchronization status
-# This check requires systemd-timesyncd and will fail if chrony/ntpd is used instead
+# Passes if systemd-timesyncd, chrony, or ntpd is active AND time is synchronized
 check_ntp_sync() {
   echo -e "\n${YELLOW}=== Time Synchronization ===${NC}"
   echo -e "${BLUE}Checking time sync service...${NC}"
@@ -772,6 +772,8 @@ check_ntp_sync() {
   local chrony_active=false
   local ntpd_active=false
   local openntpd_active=false
+  local service_found=false
+  local sync_ok=false
 
   # Check which NTP services are running
   if command -v systemctl &> /dev/null; then
@@ -796,54 +798,131 @@ check_ntp_sync() {
   # Display current sync method
   echo -e "  Current time sync: ${YELLOW}$sync_method${NC}"
 
-  # Check if systemd-timesyncd is active (required)
+  # Check for an accepted NTP service
   if [ "$timesyncd_active" = true ]; then
+    service_found=true
     echo -e "  ${GREEN}PASS: systemd-timesyncd is active${NC}"
+  elif [ "$chrony_active" = true ]; then
+    service_found=true
+    echo -e "  ${GREEN}PASS: chrony is active${NC}"
+  elif [ "$ntpd_active" = true ]; then
+    service_found=true
+    echo -e "  ${GREEN}PASS: ntpd is active${NC}"
+  elif [ "$openntpd_active" = true ]; then
+    echo -e "  ${RED}FAIL: System is using OpenNTPD which is not a recommended NTP service${NC}"
+    echo -e "  Expected: ${GREEN}systemd-timesyncd, chrony, or ntpd${NC}"
+    echo -e "  ${YELLOW}To fix (choose one):${NC}"
+    echo -e "    sudo systemctl stop openntpd && sudo systemctl disable openntpd"
+    echo -e "    sudo systemctl enable systemd-timesyncd && sudo systemctl start systemd-timesyncd"
+    return 1
+  else
+    echo -e "  ${RED}FAIL: No time synchronization service detected${NC}"
+    echo -e "  Expected: ${GREEN}systemd-timesyncd, chrony, or ntpd${NC}"
+    echo -e "  ${YELLOW}To fix (choose one):${NC}"
+    echo -e "    sudo systemctl enable systemd-timesyncd && sudo systemctl start systemd-timesyncd"
+    return 1
+  fi
+
+  # Verify the clock is actually synchronized
+  echo -e "${BLUE}Checking time synchronization status...${NC}"
+
+  if [ "$timesyncd_active" = true ]; then
+    # Check via timedatectl for systemd-timesyncd
+    local timesync_output
+    timesync_output=$(timedatectl show --property=NTPSynchronized 2>&1)
+    if echo "$timesync_output" | grep -q "NTPSynchronized=yes"; then
+      sync_ok=true
+      echo -e "  ${GREEN}PASS: System clock is synchronized (systemd-timesyncd)${NC}"
+    else
+      echo -e "  ${RED}FAIL: systemd-timesyncd is running but clock is NOT synchronized${NC}"
+      echo -e "  timedatectl reports: ${YELLOW}${timesync_output}${NC}"
+      echo -e "  ${YELLOW}To investigate:${NC}"
+      echo -e "    timedatectl timesync-status"
+      echo -e "    systemctl status systemd-timesyncd"
+      return 1
+    fi
+
+  elif [ "$chrony_active" = true ]; then
+    # Check via chronyc for chrony
+    if command -v chronyc &> /dev/null; then
+      local chrony_output
+      chrony_output=$(chronyc tracking 2>&1)
+      if [ $? -ne 0 ]; then
+        echo -e "  ${RED}FAIL: chrony is running but 'chronyc tracking' returned an error${NC}"
+        echo -e "  Output: ${YELLOW}${chrony_output}${NC}"
+        return 1
+      fi
+      local leap_status
+      leap_status=$(echo "$chrony_output" | grep "Leap status" | awk -F: '{print $2}' | xargs)
+      if [ "$leap_status" = "Normal" ]; then
+        sync_ok=true
+        echo -e "  ${GREEN}PASS: System clock is synchronized (chrony)${NC}"
+      elif [ "$leap_status" = "Not synchronised" ]; then
+        echo -e "  ${RED}FAIL: chrony is running but clock is NOT synchronized${NC}"
+        echo -e "  Leap status: ${YELLOW}${leap_status}${NC}"
+        echo -e "  ${YELLOW}To investigate:${NC}"
+        echo -e "    chronyc tracking"
+        echo -e "    chronyc sources -v"
+        return 1
+      else
+        echo -e "  ${RED}FAIL: chrony reports unexpected leap status: ${leap_status}${NC}"
+        echo -e "  ${YELLOW}To investigate:${NC}"
+        echo -e "    chronyc tracking"
+        echo -e "    chronyc sources -v"
+        return 1
+      fi
+    else
+      echo -e "  ${RED}FAIL: chrony is running but 'chronyc' command not found to verify sync${NC}"
+      echo -e "  ${YELLOW}To fix: install chrony tools so sync status can be verified${NC}"
+      echo -e "    sudo apt install chrony"
+      return 1
+    fi
+
+  elif [ "$ntpd_active" = true ]; then
+    # Check via ntpstat or ntpq for ntpd
+    if command -v ntpstat &> /dev/null; then
+      local ntpstat_output
+      ntpstat_output=$(ntpstat 2>&1)
+      if [ $? -eq 0 ]; then
+        sync_ok=true
+        echo -e "  ${GREEN}PASS: System clock is synchronized (ntpd)${NC}"
+      else
+        echo -e "  ${RED}FAIL: ntpd is running but clock is NOT synchronized${NC}"
+        echo -e "  ntpstat output: ${YELLOW}${ntpstat_output}${NC}"
+        echo -e "  ${YELLOW}To investigate:${NC}"
+        echo -e "    ntpstat"
+        echo -e "    ntpq -p"
+        return 1
+      fi
+    elif command -v ntpq &> /dev/null; then
+      # Fall back to ntpq - check if any peer is selected (marked with *)
+      local ntpq_output
+      ntpq_output=$(ntpq -p 2>&1)
+      if [ $? -ne 0 ]; then
+        echo -e "  ${RED}FAIL: ntpd is running but 'ntpq -p' returned an error${NC}"
+        echo -e "  Output: ${YELLOW}${ntpq_output}${NC}"
+        return 1
+      fi
+      if echo "$ntpq_output" | grep -q '^\*'; then
+        sync_ok=true
+        echo -e "  ${GREEN}PASS: System clock is synchronized (ntpd)${NC}"
+      else
+        echo -e "  ${RED}FAIL: ntpd is running but no sync peer selected${NC}"
+        echo -e "  ${YELLOW}To investigate:${NC}"
+        echo -e "    ntpq -p"
+        return 1
+      fi
+    else
+      echo -e "  ${RED}FAIL: ntpd is running but neither 'ntpstat' nor 'ntpq' found to verify sync${NC}"
+      echo -e "  ${YELLOW}To fix: install NTP tools so sync status can be verified${NC}"
+      echo -e "    sudo apt install ntpstat"
+      return 1
+    fi
+  fi
+
+  if [ "$sync_ok" = true ]; then
     return 0
   fi
-
-  # Fail if using chrony instead
-  if [ "$chrony_active" = true ]; then
-    echo -e "  ${RED}FAIL: System is using chrony instead of systemd-timesyncd${NC}"
-    echo -e "  Expected: ${GREEN}systemd-timesyncd${NC}"
-    echo -e "  ${YELLOW}To fix:${NC}"
-    echo -e "    sudo systemctl stop chrony"
-    echo -e "    sudo systemctl disable chrony"
-    echo -e "    sudo systemctl enable systemd-timesyncd"
-    echo -e "    sudo systemctl start systemd-timesyncd"
-    return 1
-  fi
-
-  # Fail if using ntpd instead
-  if [ "$ntpd_active" = true ]; then
-    echo -e "  ${RED}FAIL: System is using ntpd instead of systemd-timesyncd${NC}"
-    echo -e "  Expected: ${GREEN}systemd-timesyncd${NC}"
-    echo -e "  ${YELLOW}To fix:${NC}"
-    echo -e "    sudo systemctl stop ntp"
-    echo -e "    sudo systemctl disable ntp"
-    echo -e "    sudo systemctl enable systemd-timesyncd"
-    echo -e "    sudo systemctl start systemd-timesyncd"
-    return 1
-  fi
-
-  # Fail if using OpenNTPD instead
-  if [ "$openntpd_active" = true ]; then
-    echo -e "  ${RED}FAIL: System is using OpenNTPD instead of systemd-timesyncd${NC}"
-    echo -e "  Expected: ${GREEN}systemd-timesyncd${NC}"
-    echo -e "  ${YELLOW}To fix:${NC}"
-    echo -e "    sudo systemctl stop openntpd"
-    echo -e "    sudo systemctl disable openntpd"
-    echo -e "    sudo systemctl enable systemd-timesyncd"
-    echo -e "    sudo systemctl start systemd-timesyncd"
-    return 1
-  fi
-
-  # No NTP service detected
-  echo -e "  ${RED}FAIL: No time synchronization service detected${NC}"
-  echo -e "  Expected: ${GREEN}systemd-timesyncd${NC}"
-  echo -e "  ${YELLOW}To fix:${NC}"
-  echo -e "    sudo systemctl enable systemd-timesyncd"
-  echo -e "    sudo systemctl start systemd-timesyncd"
   return 1
 }
 

--- a/health_check.sh
+++ b/health_check.sh
@@ -772,7 +772,6 @@ check_ntp_sync() {
   local chrony_active=false
   local ntpd_active=false
   local openntpd_active=false
-  local service_found=false
   local sync_ok=false
 
   # Check which NTP services are running
@@ -800,13 +799,13 @@ check_ntp_sync() {
 
   # Check for an accepted NTP service
   if [ "$timesyncd_active" = true ]; then
-    service_found=true
+
     echo -e "  ${GREEN}PASS: systemd-timesyncd is active${NC}"
   elif [ "$chrony_active" = true ]; then
-    service_found=true
+
     echo -e "  ${GREEN}PASS: chrony is active${NC}"
   elif [ "$ntpd_active" = true ]; then
-    service_found=true
+
     echo -e "  ${GREEN}PASS: ntpd is active${NC}"
   elif [ "$openntpd_active" = true ]; then
     echo -e "  ${RED}FAIL: System is using OpenNTPD which is not a recommended NTP service${NC}"

--- a/health_check.sh
+++ b/health_check.sh
@@ -872,10 +872,20 @@ check_ntp_sync() {
         return 1
       fi
     else
-      echo -e "  ${RED}FAIL: chrony is running but 'chronyc' command not found to verify sync${NC}"
-      echo -e "  ${YELLOW}To fix: install chrony tools so sync status can be verified${NC}"
-      echo -e "    sudo apt install chrony"
-      return 1
+      # chronyc not available, fall back to timedatectl kernel NTP sync flag
+      local timesync_output
+      timesync_output=$(timedatectl show --property=NTPSynchronized 2>&1)
+      if echo "$timesync_output" | grep -q "NTPSynchronized=yes"; then
+        sync_ok=true
+        echo -e "  ${GREEN}PASS: System clock is synchronized (chrony via timedatectl)${NC}"
+      else
+        echo -e "  ${RED}FAIL: chrony is running but clock is NOT synchronized${NC}"
+        echo -e "  ${YELLOW}To investigate, install chronyc:${NC}"
+        echo -e "    sudo apt install chrony"
+        echo -e "    chronyc tracking"
+        echo -e "    chronyc sources -v"
+        return 1
+      fi
     fi
 
   elif [ "$ntpd_active" = true ]; then
@@ -913,10 +923,19 @@ check_ntp_sync() {
         return 1
       fi
     else
-      echo -e "  ${RED}FAIL: ntpd is running but neither 'ntpstat' nor 'ntpq' found to verify sync${NC}"
-      echo -e "  ${YELLOW}To fix: install NTP tools so sync status can be verified${NC}"
-      echo -e "    sudo apt install ntpstat"
-      return 1
+      # Neither ntpstat nor ntpq available, fall back to timedatectl kernel NTP sync flag
+      local timesync_output
+      timesync_output=$(timedatectl show --property=NTPSynchronized 2>&1)
+      if echo "$timesync_output" | grep -q "NTPSynchronized=yes"; then
+        sync_ok=true
+        echo -e "  ${GREEN}PASS: System clock is synchronized (ntpd via timedatectl)${NC}"
+      else
+        echo -e "  ${RED}FAIL: ntpd is running but clock is NOT synchronized${NC}"
+        echo -e "  ${YELLOW}To investigate, install ntpstat or ntpq:${NC}"
+        echo -e "    sudo apt install ntpstat"
+        echo -e "    ntpq -p"
+        return 1
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary
- NTP check now passes for **systemd-timesyncd**, **chrony**, or **ntpd** (previously only systemd-timesyncd was accepted)
- Added sync verification: after confirming a valid service is running, verifies the clock is actually synchronized using each daemon's native tools (`timedatectl`, `chronyc tracking`, `ntpstat`/`ntpq -p`)
- Falls back to `timedatectl show --property=NTPSynchronized` (kernel NTP sync flag) when daemon-specific CLI tools aren't installed

## Test plan
- [ ] Run on a server using systemd-timesyncd — should PASS service + sync checks
- [ ] Run on a server using chrony — should PASS service + sync checks
- [ ] Run on a server using ntpd — should PASS service + sync checks
- [ ] Stop NTP service and verify check FAILs with no service detected
- [ ] Verify sync failure is detected (e.g., block NTP traffic temporarily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)