### PR TITLE
security: add top-level workflow permissions (VGTR-1358)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # ── Python Checks ──────────────────────────────────────────────────
   python-checks:


### PR DESCRIPTION
Closes CodeQL actions/missing-workflow-permissions finding on .github/workflows/pr-checks.yml. Adds permissions: contents: read at workflow root to narrow the default GITHUB_TOKEN scope.

Tracking: VGTR-1358 Item 9, GATOR-1508.