### PR TITLE
add hkg (Hong Kong) to bam test

### DIFF
--- a/bam_ping_test.sh
+++ b/bam_ping_test.sh
@@ -8,6 +8,7 @@ HOSTS=(
     "dfw.mainnet.bam.jito.wtf"
     "dub.mainnet.bam.jito.wtf"
     "fra.mainnet.bam.jito.wtf"
+    "hkg.mainnet.bam.jito.wtf"
     "lon.mainnet.bam.jito.wtf"
     "lax.mainnet.bam.jito.wtf"
     "ewr.mainnet.bam.jito.wtf"


### PR DESCRIPTION
Adds the Hong Kong (`hkg`) endpoint to the BAM ping test host list.

## Change
- `bam_ping_test.sh`: add `hkg.mainnet.bam.jito.wtf` to `HOSTS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)